### PR TITLE
Update birthday page dates to 2026 Timmerdorp week

### DIFF
--- a/src/pages/Birthdays.tsx
+++ b/src/pages/Birthdays.tsx
@@ -11,7 +11,7 @@ const Birthdays: React.FC = () => {
 	const [error, setError] = useState<boolean>(false);
 	const [data, setData] = useState<any>(null);
 	const [days] = useState<string[]>(['di', 'wo', 'do', 'vr']);
-	const [dates] = useState<string[]>(['Dinsdag 19 augustus', 'Woensdag 20 augustus', 'Donderdag 21 augustus', 'Vrijdag 22 augustus']);
+	const [dates] = useState<string[]>(['Dinsdag 11 augustus', 'Woensdag 12 augustus', 'Donderdag 13 augustus', 'Vrijdag 14 augustus']);
 	const [currentWijk, setCurrentWijk] = useState<string>('blue');
 	const navigate = useNavigate();
 


### PR DESCRIPTION
Birthday page still showed the 2025 dates (19-22 augustus). Updated to this year's Timmerdorp week: dinsdag 11 t/m vrijdag 14 augustus.

The API (`timmerdorp-parse`, `cloud/lib/td-dates.js`) already has the correct 2026 dates, so no backend change was needed.