### PR TITLE
Fix blank Verjaardagen load, brighten yellow, align ticket editor with view

### DIFF
--- a/src/pages/Birthdays.tsx
+++ b/src/pages/Birthdays.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom';
 import apiCall from '../utils/apiCall';
 import { FaShareAlt, FaSearch, FaBirthdayCake } from 'react-icons/fa';
 import Layout from '../layouts/layout';
-import LoadingIcon from '../components/LoadingIcon';
 import '../scss/Birthdays.scss';
 
 const Birthdays: React.FC = () => {
@@ -12,16 +11,14 @@ const Birthdays: React.FC = () => {
 	const [data, setData] = useState<any>(null);
 	const [days] = useState<string[]>(['di', 'wo', 'do', 'vr']);
 	const [dates] = useState<string[]>(['Dinsdag 11 augustus', 'Woensdag 12 augustus', 'Donderdag 13 augustus', 'Vrijdag 14 augustus']);
-	const [currentWijk, setCurrentWijk] = useState<string>('blue');
+	// Read straight from storage on the first render: resolving this in the
+	// effect would paint one frame in the wrong wijk colour.
+	const [currentWijk] = useState<string>(() => localStorage.getItem('wijkName') || 'blue');
 	const navigate = useNavigate();
 
 	useEffect(() => {
 		const fetchData = async () => {
 			try {
-				// Get current wijk for theming
-				const wijkName = localStorage.getItem('wijkName') || 'blue';
-				setCurrentWijk(wijkName);
-
 				const result = await apiCall('wijkStats');
 				if (result && result.response === 'success') {
 					setData(result.birthdays);
@@ -83,24 +80,26 @@ const Birthdays: React.FC = () => {
 		navigate(`/zoek?q=${kind.name}`);
 	};
 
-	if (loading) {
-		return <LoadingIcon color="white" />;
-	}
-
-	if (error) {
-		return <div>Er is iets fout gegaan...</div>;
-	}
-
 	return (
-		<>
-			<Layout title="Verjaardagen">
-				<div className={`birthdays-page wijk-${currentWijk}`}>
-					{days.map((d, i) => (
+		<Layout title="Verjaardagen">
+			<div className={`birthdays-page wijk-${currentWijk}`}>
+				{error && (
+					<div className="empty-state">
+						<p>Er is iets fout gegaan...</p>
+					</div>
+				)}
+
+				{/* The four days are fixed, so their headings paint immediately and
+				    only the lists wait on the API. */}
+				{!error && days.map((d, i) => {
+					const day = loading ? null : data?.[d];
+
+					return (
 						<section key={d} id={d} className="section birthday-day">
 							<div className="day-header">
 								<h2 className="section-title">{dates[i]}</h2>
-								<span className="day-count nums">{data[d].count}</span>
-								{data[d].kids.length > 0 && (
+								{day && <span className="day-count nums">{day.count}</span>}
+								{day && day.kids.length > 0 && (
 									<button
 										type="button"
 										className="fab day-share"
@@ -113,13 +112,18 @@ const Birthdays: React.FC = () => {
 								)}
 							</div>
 
-							{data[d].kids.length === 0 ? (
+							{!day ? (
+								<div className="birthday-list" aria-hidden="true">
+									<div className="birthday-card is-skeleton" />
+									<div className="birthday-card is-skeleton" />
+								</div>
+							) : day.kids.length === 0 ? (
 								<div className="empty-state">
 									<p>Geen kinderen jarig</p>
 								</div>
 							) : (
 								<div className="birthday-list">
-									{data[d].kids.map((bday: any, idx: number) => (
+									{day.kids.map((bday: any, idx: number) => (
 										<button
 											type="button"
 											key={idx}
@@ -142,10 +146,10 @@ const Birthdays: React.FC = () => {
 								</div>
 							)}
 						</section>
-					))}
-				</div>
-			</Layout>
-		</>
+					);
+				})}
+			</div>
+		</Layout>
 	);
 };
 

--- a/src/pages/EditTicket.tsx
+++ b/src/pages/EditTicket.tsx
@@ -11,6 +11,7 @@ interface Ticket {
 
 interface TicketProperty {
 	label: string;
+	appLabel?: string;
 }
 
 interface TicketPropertiesMap {
@@ -33,12 +34,22 @@ const getWijkThemeClass = (hutNr: string) => {
 	}
 };
 
-function ViewTicket() {
-	const [loading, setLoading] = useState(false);
+// Phone and email fields get the matching keyboard and the same semantics the
+// view page gives them when it renders tel:/mailto: links.
+const getInputType = (prop: string) => {
+	if (prop.startsWith('tel')) return 'tel';
+	if (prop.endsWith('email')) return 'email';
+	return 'text';
+};
+
+function EditTicket() {
+	const [loading, setLoading] = useState(true);
 	const [ticket, setTicket] = useState<Ticket>({});
 	const [ticketPropertiesMap, setTicketPropertiesMap] = useState<TicketPropertiesMap>({});
 	const navigate = useNavigate();
 
+	// Mirrors the view page's groups, so the same fields sit under the same
+	// headings in both directions.
 	const tableCategories = [
 		{
 			name: 'Gegevens Kind',
@@ -61,7 +72,6 @@ function ViewTicket() {
 		if (!ticketId) {
 			navigate('/zoek');
 		} else {
-			setLoading(true);
 			apiCall('findChildById', { id: ticketId }).then((result) => {
 				setLoading(false);
 
@@ -88,20 +98,27 @@ function ViewTicket() {
 
 	const cancel = () => navigate('/bekijk-ticket?ticket-id=' + ticket.id, { replace: true });
 
+	const getLabel = (prop: string) =>
+		(ticketPropertiesMap[prop] || {}).appLabel || (ticketPropertiesMap[prop] || {}).label || prop;
+
 	const displayName = [ticket.firstName, ticket.lastName].filter(Boolean).join(' ');
 
 	return (
-		<Layout noHeader={true} noPadding={true}>
+		<Layout title="" noPadding={true} onBack={cancel} theme={getWijkThemeClass(ticket.hutNr).replace('theme-', '')}>
 			<LoadingIcon shown={loading} />
 			{!loading &&
 				<div className={'ticketCard ticket-edit ' + getWijkThemeClass(ticket.hutNr)}>
-					<div className="ticket-topbar">
-						<button className="ticket-close" onClick={cancel} title="Annuleren" aria-label="Annuleren">
-							✕
-						</button>
-					</div>
-
 					<h1 className="ticket-name">{displayName || 'Ticket bewerken'}</h1>
+
+					{/* Same identity chips as the view page; they track what you type. */}
+					<div className="ticket-subline">
+						{ticket.wristband
+							? <span className="ticket-chip">Bandje {ticket.wristband}</span>
+							: <span className="ticket-chip neutral">Nog geen bandje</span>}
+						{ticket.hutNr
+							? <span className="ticket-chip">Hutje {ticket.hutNr}</span>
+							: <span className="ticket-chip neutral">Nog geen hutje</span>}
+					</div>
 
 					<div className="ticket-group">
 						<h3>Naam</h3>
@@ -137,17 +154,26 @@ function ViewTicket() {
 							<div className="ticket-fields">
 								{cat.props.map((prop) =>
 									<div className="ticket-field" key={prop}>
-										<label htmlFor={'field-' + prop}>
-											{(ticketPropertiesMap[prop] || {}).label}
-										</label>
-										<input
-											id={'field-' + prop}
-											type="text"
-											title={(ticketPropertiesMap[prop] || {}).label}
-											onChange={(e) => setTicket({ ...ticket, [prop]: e.target.value })}
-											value={ticket[prop]}
-											placeholder={(ticketPropertiesMap[prop] || {}).label}
-										/>
+										<label htmlFor={'field-' + prop}>{getLabel(prop)}</label>
+										{prop === 'opmerkingen' ? (
+											<textarea
+												id={'field-' + prop}
+												rows={3}
+												title={getLabel(prop)}
+												onChange={(e) => setTicket({ ...ticket, [prop]: e.target.value })}
+												value={ticket[prop] || ''}
+												placeholder={getLabel(prop)}
+											/>
+										) : (
+											<input
+												id={'field-' + prop}
+												type={getInputType(prop)}
+												title={getLabel(prop)}
+												onChange={(e) => setTicket({ ...ticket, [prop]: e.target.value })}
+												value={ticket[prop] || ''}
+												placeholder={getLabel(prop)}
+											/>
+										)}
 									</div>
 								)}
 							</div>
@@ -163,4 +189,4 @@ function ViewTicket() {
 	);
 }
 
-export default ViewTicket;
+export default EditTicket;

--- a/src/pages/ViewTicket.tsx
+++ b/src/pages/ViewTicket.tsx
@@ -38,7 +38,9 @@ const getWijkThemeClass = (hutNr: string) => {
 };
 
 function ViewTicket() {
-	const [loading, setLoading] = useState(false);
+	// Starts true: the effect always either fetches or navigates away, and
+	// false here paints an empty card for a frame first.
+	const [loading, setLoading] = useState(true);
 	const [ticket, setTicket] = useState<Ticket>({});
 	const [ticketPropertiesMap, setTicketPropertiesMap] = useState<TicketPropertiesMap>({});
 	const [canEditTickets, setCanEditTickets] = useState(false);
@@ -66,7 +68,6 @@ function ViewTicket() {
 		if (!ticketId) {
 			navigate('/zoek');
 		} else {
-			setLoading(true);
 			apiCall('findChildById', { id: ticketId }).then((result) => {
 				setLoading(false);
 

--- a/src/scss/Birthdays.scss
+++ b/src/scss/Birthdays.scss
@@ -169,6 +169,31 @@
 		}
 	}
 
+	// ---- Placeholder while the API is still out --------------------
+	// Same box as a real card so nothing shifts when the data lands.
+	.birthday-card.is-skeleton {
+		height: 76px;
+		border-left-color: var(--c-border);
+		background: var(--c-surface);
+		animation: birthday-skeleton-pulse 1.4s ease-in-out infinite;
+
+		&:nth-child(2) {
+			animation-delay: 0.18s;
+			opacity: 0.6;
+		}
+	}
+
+	@keyframes birthday-skeleton-pulse {
+		0%, 100% { opacity: 0.75; }
+		50% { opacity: 0.4; }
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.birthday-card.is-skeleton {
+			animation: none;
+		}
+	}
+
 	.empty-state {
 		padding: var(--s-6) var(--s-5);
 		background: var(--c-surface);

--- a/src/scss/Ticket.scss
+++ b/src/scss/Ticket.scss
@@ -15,35 +15,6 @@
 	padding: 0 var(--gutter) calc(var(--s-10) + var(--safe-bottom));
 }
 
-.ticket-topbar {
-	position: sticky;
-	top: 0;
-	z-index: 20;
-	display: flex;
-	align-items: center;
-	justify-content: flex-end;
-	height: calc(var(--appbar-h) + var(--safe-top));
-	padding-top: var(--safe-top);
-	margin: 0 calc(var(--gutter) * -1);
-	padding-right: var(--s-3);
-	background: color-mix(in srgb, var(--c-bg) 88%, transparent);
-	backdrop-filter: blur(12px);
-	-webkit-backdrop-filter: blur(12px);
-
-	.ticket-close {
-		width: var(--tap);
-		height: var(--tap);
-		min-height: var(--tap);
-		padding: 0;
-		border-radius: var(--r-full);
-		background: var(--c-surface);
-		color: var(--c-text-2);
-		box-shadow: var(--e-1);
-		font-size: 1.125rem;
-		line-height: 1;
-	}
-}
-
 .ticket-name {
 	margin: var(--s-2) 0 var(--s-1);
 	font-family: var(--font-display);
@@ -136,18 +107,14 @@
 		color: var(--wijk);
 		font-weight: 650;
 	}
-
-	// Edit mode: inputs sit flush inside the value cell.
-	input[type="text"] {
-		min-height: 40px;
-		padding: 0 var(--s-3);
-		font-size: var(--t-small);
-	}
 }
 
 // ---- Edit form ------------------------------------------------
-// Label above input, stacked: on a 390px phone a two-column table
-// leaves the input too narrow to read what you typed.
+// The same card, dividers and row rhythm as .ticket-table on the view
+// page, so the two read as one screen in two modes. The one deliberate
+// difference: label above input rather than beside it, because on a
+// 390px phone a two-column row leaves the input too narrow to read
+// what you typed.
 
 .ticket-fields {
 	background: var(--c-surface);
@@ -164,23 +131,39 @@
 		border-bottom: none;
 	}
 
+	// Matches the view table's label column exactly.
 	label {
+		display: block;
 		margin-bottom: var(--s-1);
 		font-size: var(--t-micro);
 		font-weight: 600;
 		color: var(--c-text-3);
 	}
 
-	input[type="text"] {
-		min-height: var(--tap);
-		padding: 0 var(--s-3);
+	input,
+	textarea {
+		width: 100%;
 		background: var(--c-surface-sunken);
 		border-color: transparent;
+		font-size: var(--t-small);
+		font-weight: 550;
 
 		&:focus {
 			background: var(--c-surface);
 			border-color: var(--wijk);
 		}
+	}
+
+	input {
+		min-height: var(--tap);
+		padding: 0 var(--s-3);
+	}
+
+	textarea {
+		min-height: 84px;
+		padding: var(--s-2) var(--s-3);
+		line-height: 1.45;
+		resize: vertical;
 	}
 }
 
@@ -206,9 +189,11 @@
 	backdrop-filter: blur(12px);
 	-webkit-backdrop-filter: blur(12px);
 
+	// Same button metrics as .ticket-actions on the view page.
 	button {
 		flex: 1 1 auto;
 		min-height: 50px;
+		font-size: var(--t-small);
 	}
 
 	// Cancel is the smaller escape hatch; save owns the width.

--- a/src/scss/_tokens.scss
+++ b/src/scss/_tokens.scss
@@ -24,9 +24,11 @@
 	--green-soft: #e6f6ed;
 	--green-ink: #0c4a29;
 
-	--yellow: #f7b32b;
+	// Brighter and less amber than the other three; --yellow-deep stays
+	// dark because it is the text tone on light surfaces.
+	--yellow: #ffc61a;
 	--yellow-deep: #cf8f0d;
-	--yellow-soft: #fef5e3;
+	--yellow-soft: #fff7e0;
 	--yellow-ink: #6d4a05;
 
 	// ---- Warm neutrals ----------------------------------------

--- a/src/scss/vars.scss
+++ b/src/scss/vars.scss
@@ -9,7 +9,7 @@ $darkGrey: #d3ccc0;
 $mediumBlack: #1e1c19;
 $blue: #2f6fed;
 $liliac: #b79bff;
-$yellow: #f7b32b;
+$yellow: #ffc61a;
 $green: #1fa45c;
 $red: #e14434;
 $darkTextColor: #3a2a03;


### PR DESCRIPTION
Follow-up fixes on top of the frontend revamp (#374).

## Verjaardagen loaded to a completely blank page

Two bugs compounding:

- `Birthdays.tsx` returned its loading state **before** `<Layout>`, so no header or tab bar rendered while the API call was out. Every other page renders the shell and puts the spinner inside it.
- The spinner it returned was `<LoadingIcon color="white" />` with no `shown` prop, and `LoadingIcon.scss` sets `display: none` without `.shown`. So it rendered nothing at all: the page was blank white, not even a hammer.

Now the Layout paints immediately with the four day headings (those dates are static and never needed the API), and each day shows two placeholder cards that swap for real data in place. The wijk lookup also moved out of the effect into the `useState` initialiser so the theme doesn't flip on the first frame.

Not fixed here: the wait itself is backend. `app-wijkStats` fetches up to 1000 full `Ticket` objects plus every `Admin` just to derive four days of birthdays. A `select()` for the six fields actually used would cut the payload substantially, but that lives in `timmerdorp-parse`.

## Brighter yellow

`--yellow` goes from `#f7b32b` (a fairly amber gold) to `#ffc61a`, with `--yellow-soft` lifted to match. `--yellow-deep` deliberately stays dark: it is the text tone on light surfaces in Statistics, and brightening it would hurt contrast. The yellow theme already uses dark ink on `--wijk`, so the brighter hue only improves readability.

## Edit ticket now matches view ticket

The divergence was chrome, not content. Edit used `noHeader` with its own sticky bar and an ✕ button, and never passed `theme` to Layout, so it lost the child's wijk colour on the app bar. It also had no identity chips.

- Identical `<Layout title="" noPadding onBack theme={wijk}>` call, so both pages get the same app bar in the same wijk colour.
- Same `.ticket-name` heading and bandje/hutje chips, which track what you type.
- Field labels use `appLabel || label`, matching the view page.
- Phone and email fields get `tel`/`email` input types, matching the `tel:`/`mailto:` links view renders; `opmerkingen` becomes a textarea.
- Deleted the now-dead `.ticket-topbar` block and an unused `.ticket-table input` rule.

Labels stay above inputs rather than beside them. There is a comment in `Ticket.scss` explaining why and it is right: a two-column row on a 390px phone leaves the input too narrow to read. The card, dividers, row padding and label typography now match the view table, so it reads as one screen in two modes.

Both pages also start with `loading` true, since the effect always either fetches or navigates away, and `false` painted an empty card for a frame first.

## Verification

`tsc --noEmit` and `npm run build` both clean. Not clicked through in a browser (the pages are behind Parse admin auth), so the brighter yellow is worth a look on Home, where the info band and tab bar darken `--wijk`.
