### PR TITLE
Add fuchsia as a badge wijk, alongside white/EHBO

### DIFF
--- a/src/components/WijkPicker.tsx
+++ b/src/components/WijkPicker.tsx
@@ -11,6 +11,7 @@ export const WIJKEN = [
 	{ key: 'red', label: 'Rood' },
 	{ key: 'yellow', label: 'Geel' },
 	{ key: 'white', label: 'Wit / EHBO' },
+	{ key: 'fuchsia', label: 'Fuchsia' },
 ];
 
 interface WijkPickerProps {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -176,7 +176,9 @@ function Home() {
 			if (result && result.response === 'success') {
 				let dag = ['di', 'wo', 'do', 'vr'][new Date().getDay() - 2];
 
-				const currentWijk = wijk === 'white' ? 'blue' : wijk;
+				// wijkStats only buckets the four hut-backed wijken; white/EHBO and
+				// fuchsia are badge-only wijken with no hut range, so fall back.
+				const currentWijk = (wijk === 'white' || wijk === 'fuchsia') ? 'blue' : wijk;
 				setWijkCount(result.quarters?.[currentWijk]?.['aanwezig_' + dag] || 0);
 				setChildrenCount(result['aanwezig_' + dag] || 0);
 				setBirthdays((result.birthdays?.[dag] || {}).count || 0);

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -155,6 +155,7 @@ function Settings() {
 			red: 'Rood',
 			yellow: 'Geel',
 			white: 'Wit/EHBO',
+			fuchsia: 'Fuchsia',
 		}[englishWijkName];
 		setWijkName(wijkNaam || 'Onbekend');
 
@@ -164,6 +165,7 @@ function Settings() {
 			red: 'rood',
 			yellow: 'geel',
 			white: 'wit',
+			fuchsia: 'fuchsia',
 		}[englishWijkName];
 
 		document.cookie = `wijk=${wijkCookie}; path=/; max-age=31536000`;

--- a/src/scss/Statistics.scss
+++ b/src/scss/Statistics.scss
@@ -107,12 +107,16 @@
 		td.white {
 			color: var(--c-text);
 		}
+		td.fuchsia {
+			color: var(--fuchsia-deep);
+		}
 
 		td.blue,
 		td.red,
 		td.green,
 		td.yellow,
-		td.white {
+		td.white,
+		td.fuchsia {
 			font-weight: 700;
 		}
 

--- a/src/scss/WijkPicker.scss
+++ b/src/scss/WijkPicker.scss
@@ -74,6 +74,9 @@
 		--swatch: var(--yellow);
 		--swatch-ink: var(--yellow-ink);
 	}
+	&.fuchsia {
+		--swatch: var(--fuchsia);
+	}
 
 	// Wit/EHBO gets the full width: it is the odd one out, and a white tile
 	// beside a coloured one otherwise reads as an empty slot.

--- a/src/scss/_tokens.scss
+++ b/src/scss/_tokens.scss
@@ -33,6 +33,13 @@
 	--yellow-soft: #fffade;
 	--yellow-ink: #6a4d00;
 
+	// Fuchsia: a non-hut wijk, same treatment as white/EHBO — a badge
+	// colour for admins, not a hut-number-backed district.
+	--fuchsia: #cc2d8c;
+	--fuchsia-deep: #9c1e69;
+	--fuchsia-soft: #fce9f3;
+	--fuchsia-ink: #6e1350;
+
 	// ---- Warm neutrals ----------------------------------------
 	// Slightly warm so the app reads like paper and timber rather
 	// than a cold dashboard.
@@ -175,4 +182,13 @@
 	--wijk-soft: var(--n-50);
 	--wijk-ink: var(--n-800);
 	--on-wijk: var(--n-900);
+}
+
+// Fuchsia: another non-hut badge wijk, alongside white/EHBO.
+.theme-fuchsia {
+	--wijk: var(--fuchsia);
+	--wijk-deep: var(--fuchsia-deep);
+	--wijk-soft: var(--fuchsia-soft);
+	--wijk-ink: var(--fuchsia-ink);
+	--on-wijk: #ffffff;
 }

--- a/src/utils/getWijkHexColor.ts
+++ b/src/utils/getWijkHexColor.ts
@@ -8,6 +8,8 @@ const getWijkHexColor = (wijkName: string): string => {
 			return '#2196f3';
 		case 'green':
 			return '#43a047';
+		case 'fuchsia':
+			return '#cc2d8c'; // keep in sync with --fuchsia in _tokens.scss
 		default:
 			return '#2196f3'; // default fallback to blue
 	}


### PR DESCRIPTION
## Summary
- Adds fuchsia as a new selectable wijk in the wijk picker (first-run overlay and "Wijk wijzigen"), Settings display, and theming tokens.
- Fuchsia is a **badge wijk**, same pattern as White/EHBO: an admin can pick it for themselves, but it isn't tied to a hut-number range, so it's excluded from hut/statistics-based groupings (same as white already was).

## Changes
- `_tokens.scss` — new `--fuchsia*` design tokens and `.theme-fuchsia` class
- `WijkPicker.tsx` / `WijkPicker.scss` — new option + swatch
- `Settings.tsx` — Dutch label ("Fuchsia") and cookie value
- `Statistics.scss` — leaderboard row coloring for fuchsia admins
- `Home.tsx` / `getWijkHexColor.ts` — extended the existing white-only fallbacks (wijk-stats bucket, status-bar color) to also cover fuchsia, since neither is hut-backed

## Related
Companion backend change: SHoogland/timmerdorp-parse PR #576 (adds `'fuchsia'` to the `setAdminWijk` validation allowlist). This frontend PR lets an admin select fuchsia immediately, so it should merge together with (or after) the backend PR — otherwise saving the wijk choice would fail server-side validation.

## Test plan
- `npx tsc --noEmit` — passes
- `npx vite build` — builds cleanly

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzgC4AgF8igSXbx6wwiA9D)_