### PR TITLE
Fix attendance auto-search losing leading zeros from wristband param

### DIFF
--- a/src/pages/Attendance.tsx
+++ b/src/pages/Attendance.tsx
@@ -44,7 +44,10 @@ function Attendance() {
 			setWristbandNumber(bandjeParam);
 			// Use setTimeout to ensure the component is fully mounted
 			setTimeout(() => {
-				search(parseInt(bandjeParam));
+				// Pass the raw string, not parseInt(bandjeParam) — that stripped
+				// leading zeros (e.g. "007" -> 7 -> "7"), which then failed to
+				// match the zero-padded wristband stored on the ticket.
+				search(bandjeParam);
 			}, 100);
 		}
 	}, [navigate])
@@ -118,7 +121,11 @@ function Attendance() {
 		}
 	};
 
-	const search = (wristband: number) => {
+	const search = (wristband: number | string) => {
+		// Wristbands are zero-padded 3-digit strings ("007", "042", ...) and
+		// the backend matches on the exact string, so this must never round
+		// through a number — parseInt/String would drop the leading zeros
+		// and silently fail to find the ticket.
 		const wristbandStr = String(wristband);
 		setSearchIsLoading(true);
 		setHasSearched(false);


### PR DESCRIPTION
## Bug
Navigating from a child's ticket detail page to "Naar aanwezigheid" (`/aanwezigheid?bandje=…`) silently failed to find the child for any wristband number 000–099. Manually retyping the wristband number in the Attendance search box "fixed" it.

## Root cause
Wristbands are stored and matched as zero-padded 3-digit **strings** (`"007"`, `"042"`, …) — the backend's `find-child-by-wristband.js` does an exact string match (`Parse.Query('Ticket').equalTo('wristband', wristband)`).

The auto-search effect in `Attendance.tsx` called `search(parseInt(bandjeParam))`. `parseInt("042")` strips the leading zero to `42`, which then stringifies back to `"42"` — never matching the stored `"042"`, so the query came back empty.

Typing directly into the search box doesn't hit this path: `wristbandInputChange` forwards the raw string straight to `search()`, no numeric round-trip, so it always worked.

## Fix
- Pass the raw `bandjeParam` string straight to `search()` instead of `parseInt(bandjeParam)`.
- Widened `search()`'s parameter type to `number | string` to match how it's actually called from both the auto-search effect and the manual input handler.

## Test plan
- `npx tsc --noEmit` — passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzgC4AgF8igSXbx6wwiA9D)_