### PR TITLE
Statistics: show Friday consistently in the attendance overview

### DIFF
--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -34,7 +34,7 @@ function Statistics() {
 		{ title: "Aanwezig di", prop: "aanwezig_di" },
 		{ title: "Aanwezig wo", prop: "aanwezig_wo" },
 		{ title: "Aanwezig do", prop: "aanwezig_do" },
-		...(statistieken?.aanwezig_vr !== undefined ? [{ title: "Aanwezig vr", prop: "aanwezig_vr" }] : []),
+		{ title: "Aanwezig vr", prop: "aanwezig_vr" },
 	];
 
 	const allprops = [
@@ -266,7 +266,6 @@ function Statistics() {
 		updateData();
 	};
 
-	const showVrijdag = admins.some((admin) => admin.vr !== undefined);
 	// The attendance battle is meaningless until someone has actually checked
 	// a child in, so it stays hidden until the first presence is recorded.
 	// Data-driven on purpose: duplicating the event dates from the API here
@@ -353,11 +352,9 @@ function Statistics() {
 									<td>
 										Donderdag
 									</td>
-									{showVrijdag && (
-										<td>
-											Vrijdag
-										</td>
-									)}
+									<td>
+										Vrijdag
+									</td>
 									<td>
 										Totaal
 									</td>
@@ -368,9 +365,7 @@ function Statistics() {
 										<td>{admin.di || 0}</td>
 										<td>{admin.wo || 0}</td>
 										<td>{admin.do || 0}</td>
-										{showVrijdag && (
-											<td>{admin.vr || 0}</td>
-										)}
+										<td>{admin.vr || 0}</td>
 										<td>{admin.total || 0}</td>
 									</tr>
 								))}


### PR DESCRIPTION
## Bug: Friday was singled out in the Statistics overview
Both tables on the Statistics page treated Friday differently from Tuesday/Wednesday/Thursday:

- **Aanwezigheid per wijk** table: the `Aanwezig vr` row only rendered once `statistieken.aanwezig_vr !== undefined`. The di/wo/do rows always render unconditionally, falling back to `–` when there's no data — vr was the only one hidden entirely instead.
- **Aanwezigheidsstrijd** leaderboard: same asymmetry — the `Vrijdag` column (header and cells) only rendered once at least one admin had a defined `kidspresent_vr`, while Dinsdag/Woensdag/Donderdag always render.

Friday attendance is fully wired up correctly everywhere else in the stack (`toggle-presence.js`, `wijk-stats.js`, `generate-statistics.js`, `Attendance.tsx`'s day detection all already handle `vr`/`fri` the same as the other three days) — this was purely a leftover UI guard from when Friday was added later (`0f88c24`, "include presence on friday if it exists"). Fix: render Friday exactly like the other three days, with the same `–` fallback.

## Out of scope (for now)
Also found a separate, pre-existing bug on this page: the "Aantal kinderen op het terrein" headcount graph never shows data on any day (it queries a hardcoded, never-written `day: 'sat'`, and separately its visibility flag is never flipped to `true` even on success). Left untouched here — happy to open a follow-up for it if wanted.

## Test plan
- `npx tsc --noEmit` — passes
- `npx vite build` — builds cleanly