### PR TITLE
Attendance: fix stale-closure bug hiding "already present" state on auto-search

### DIFF
--- a/src/pages/Attendance.tsx
+++ b/src/pages/Attendance.tsx
@@ -35,7 +35,8 @@ function Attendance() {
 			weekday = 'Dinsdag';
 		}
 		setWeekdayDisplayname(weekday);
-		setWeekday(weekday.substring(0, 2).toLowerCase());
+		const dayCode = weekday.substring(0, 2).toLowerCase();
+		setWeekday(dayCode);
 
 		// Check for wristband parameter in URL and auto-search
 		const urlParams = new URLSearchParams(window.location.search);
@@ -47,7 +48,12 @@ function Attendance() {
 				// Pass the raw string, not parseInt(bandjeParam) — that stripped
 				// leading zeros (e.g. "007" -> 7 -> "7"), which then failed to
 				// match the zero-padded wristband stored on the ticket.
-				search(bandjeParam);
+				// Also pass dayCode explicitly: setWeekday() above hasn't been
+				// applied yet when this closure was created, so search() would
+				// otherwise read the stale initial weekday state ('') and never
+				// detect the child as already present — the button then always
+				// said "Aanwezig melden" instead of "Afwezig melden".
+				search(bandjeParam, dayCode);
 			}, 100);
 		}
 	}, [navigate])
@@ -121,12 +127,18 @@ function Attendance() {
 		}
 	};
 
-	const search = (wristband: number | string) => {
+	const search = (wristband: number | string, dayOverride?: string) => {
 		// Wristbands are zero-padded 3-digit strings ("007", "042", ...) and
 		// the backend matches on the exact string, so this must never round
 		// through a number — parseInt/String would drop the leading zeros
 		// and silently fail to find the ticket.
 		const wristbandStr = String(wristband);
+		// dayOverride lets callers (the mount-time auto-search) pass the day
+		// code straight through instead of reading the weekday state, which
+		// may not have applied yet in their closure. Manual searches from the
+		// input always run after that state has settled, so the fallback is
+		// safe there.
+		const day = dayOverride || weekday;
 		setSearchIsLoading(true);
 		setHasSearched(false);
 		apiCall('findChildByWristband', { wristband: wristbandStr }).then((result) => {
@@ -145,13 +157,13 @@ function Attendance() {
 
 
 			// Check if it's Wednesday, Thursday, or Friday and if the ticket has no hutNr
-			if ((weekday === 'wo' || weekday === 'do' || weekday === 'vr') && !result.ticket.hutNr) {
+			if ((day === 'wo' || day === 'do' || day === 'vr') && !result.ticket.hutNr) {
 				alert('Let op: Dit kind heeft nog geen hutnummer!!!');
 			}
 
 			setFoundChild(result.ticket);
 			setHasFoundChild(true);
-			setFoundChildIsAlreadyPresent(result.ticket['aanwezig_' + weekday]);
+			setFoundChildIsAlreadyPresent(result.ticket['aanwezig_' + day]);
 		});
 	}
 


### PR DESCRIPTION
## Bug
Navigating from a child's ticket detail page to "Naar aanwezigheid" and finding a child who's already marked present today, the action button still read **"Aanwezig melden"** instead of **"Afwezig melden"** — even though the "Aanwezig vandaag" badge above it correctly said "Ja".

## Root cause
`Attendance.tsx`'s mount effect computes today's day code and calls `setWeekday(dayCode)`, then (for the `?bandje=` auto-search path) schedules `search(bandjeParam)` via `setTimeout`. That `setTimeout` callback's closure over `search()` was captured **during the same effect run**, before the `setWeekday()` state update had actually applied — so at that point `weekday` was still `''`, its initial value.

Inside `search()`:
```js
setFoundChildIsAlreadyPresent(result.ticket['aanwezig_' + weekday]);
```
resolved to `result.ticket['aanwezig_']`, always `undefined` → always falsy → the button always rendered as if the child weren't present yet.

The "Aanwezig vandaag" badge didn't share this bug because `isPresentToday` is computed fresh at render time from the *current* `weekday` state, not from a stale closure — hence the visible mismatch between the two.

Manual searches typed into the input aren't affected: by the time a user can type, the `weekday` state has long since settled.

## Fix
Compute the day code once, synchronously, in the mount effect (`dayCode`) and pass it straight into `search(wristband, dayOverride)` for the auto-search call, instead of relying on the `weekday` state having landed. `search()` now takes an optional `dayOverride` param and falls back to the `weekday` state for the (unaffected) manual-input path.

## Test plan
- `npx tsc --noEmit` — passes
- `npx vite build` — builds cleanly

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzgC4AgF8igSXbx6wwiA9D)_