### PR TITLE
Hutjes beheren: add vorige/volgende buttons to step between hut numbers

### DIFF
--- a/src/pages/HutjesManagement.tsx
+++ b/src/pages/HutjesManagement.tsx
@@ -1,6 +1,7 @@
 
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { FaChevronLeft, FaChevronRight } from 'react-icons/fa';
 import Layout from '../layouts/layout';
 import apiCall from '../utils/apiCall';
 import LoadingIcon from '../components/LoadingIcon';
@@ -41,17 +42,22 @@ function HutjesManagement() {
 		return ({ '0': 'yellow', '1': 'red', '2': 'blue', '3': 'green' } as Record<string, string>)[hutNr[0]];
 	};
 
-	const search = async () => {
+	// hutNrOverride lets callers (vorige/volgende) search a specific hut
+	// immediately, without waiting on the debounced effect below and
+	// without reading the hutNummer state — which, right after a
+	// setHutNummer() call in the same handler, wouldn't have updated yet.
+	const search = async (hutNrOverride?: string) => {
+		const targetHut = hutNrOverride || hutNummer;
 		setKidsInHut([]);
 		setErrorTitle('');
 		setErrorHelpText('');
-		if (hutNummer.length < 3) {
+		if (targetHut.length < 3) {
 			return;
 		}
 		setLoading(true);
 
 		try {
-			const result = await apiCall('searchHut', { hutNr: hutNummer });
+			const result = await apiCall('searchHut', { hutNr: targetHut });
 			setLoading(false);
 
 			if (!result || result.response !== 'success') {
@@ -61,7 +67,7 @@ function HutjesManagement() {
 			}
 
 			setHasSearchedForHut(true);
-			setLastSearchedHut(hutNummer);
+			setLastSearchedHut(targetHut);
 			setHutHistory(result.history);
 			setKidsInHut(result.tickets.sort((a: Ticket, b: Ticket) => a.firstName.localeCompare(b.firstName)));
 		} catch (e) {
@@ -91,6 +97,26 @@ function HutjesManagement() {
 		setHutNummer(newhutNummer);
 		setHasSearchedForHut(false);
 		setLastSearchedHut('');
+	};
+
+	// Vorige/volgende: step the 3-digit hut number by 1, clamped to a valid
+	// 3-digit code (000-999). Hut numbers aren't validated against a fixed
+	// list anywhere else in the app either, so this just walks the numeric
+	// sequence rather than trying to skip to the next *occupied* hut.
+	const goToAdjacentHut = (delta: number) => {
+		if (hutNummer.length !== 3 || loading) return;
+		const current = parseInt(hutNummer, 10);
+		if (isNaN(current)) return;
+
+		const nextHutNr = String(Math.min(999, Math.max(0, current + delta))).padStart(3, '0');
+		// Mark the target hut as already "searched" before hutNummer updates,
+		// so the debounced effect below (which also watches hutNummer) sees
+		// its own guard satisfied and doesn't schedule a second, redundant
+		// fetch 500ms after the one triggered directly below.
+		setHasSearchedForHut(true);
+		setLastSearchedHut(nextHutNr);
+		setHutNummer(nextHutNr);
+		search(nextHutNr);
 	};
 
 	const removeKidFromHut = (kid: Ticket) => {
@@ -203,6 +229,9 @@ function HutjesManagement() {
 	};
 
 	const hutIsOpen = hasSearchedForHut && !errorTitle;
+	const currentHutAsNumber = hutNummer.length === 3 ? parseInt(hutNummer, 10) : NaN;
+	const canGoToPreviousHut = !loading && !isNaN(currentHutAsNumber) && currentHutAsNumber > 0;
+	const canGoToNextHut = !loading && !isNaN(currentHutAsNumber) && currentHutAsNumber < 999;
 
 	return (
 		<Layout title='Hutjes beheren' theme={hutTheme(hutNummer)}>
@@ -221,6 +250,27 @@ function HutjesManagement() {
 							placeholder="000"
 						/>
 						<LoadingIcon shown={loading} />
+					</div>
+
+					<div className="hut-nav">
+						<button
+							type="button"
+							className="btn-secondary hut-nav-btn"
+							onClick={() => goToAdjacentHut(-1)}
+							disabled={!canGoToPreviousHut}
+						>
+							<FaChevronLeft aria-hidden="true" />
+							Vorige
+						</button>
+						<button
+							type="button"
+							className="btn-secondary hut-nav-btn"
+							onClick={() => goToAdjacentHut(1)}
+							disabled={!canGoToNextHut}
+						>
+							Volgende
+							<FaChevronRight aria-hidden="true" />
+						</button>
 					</div>
 				</div>
 

--- a/src/scss/Hutjes.scss
+++ b/src/scss/Hutjes.scss
@@ -51,6 +51,20 @@
 				height: 42px;
 			}
 		}
+
+		// Steps the numeric hut code by 1, so a volunteer can walk down a
+		// row of huts without retyping the number each time.
+		.hut-nav {
+			display: flex;
+			gap: var(--s-2);
+			margin-top: var(--s-2);
+		}
+
+		.hut-nav-btn {
+			flex: 1;
+			min-height: var(--tap);
+			font-size: var(--t-small);
+		}
 	}
 
 	// ---- Error callout ------------------------------------------


### PR DESCRIPTION
## Summary
Adds "Vorige" / "Volgende" buttons to the Hutjes beheren page, next to the hut number field, so an admin can step through hut numbers one at a time instead of retyping each 3-digit code.

- Steps the numeric hut code by ±1, clamped to a valid 3-digit range (`000`-`999`). Hut numbers aren't validated against any fixed list elsewhere in the app (`searchHut` just queries whatever 3-digit string it's given), so this walks the numeric sequence rather than trying to skip to the next *occupied* hut.
- Disabled at the low/high ends (`000`/`999`), while loading, or when the field doesn't currently hold a valid 3-digit number.
- Searches immediately on click rather than waiting on the existing 500ms typing debounce.

## Implementation notes
- `search()` now takes an optional `hutNrOverride` param so the button handler can search the target hut directly, instead of reading the `hutNummer` state right after setting it in the same handler (which wouldn't have updated yet — same class of stale-state bug fixed on the Attendance page recently).
- `hasSearchedForHut`/`lastSearchedHut` are pre-set to the target hut before `hutNummer` changes, so the existing debounced effect (which also watches `hutNummer`) sees its own already-searched guard satisfied and doesn't fire a redundant second fetch 500ms after the button-triggered one.

## Test plan
- `npx tsc --noEmit` — passes
- `npx vite build` — builds cleanly

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzgC4AgF8igSXbx6wwiA9D)_